### PR TITLE
3 async

### DIFF
--- a/dev.requirements.txt
+++ b/dev.requirements.txt
@@ -5,3 +5,5 @@ pytest
 requests
 async-exit-stack
 async-generator
+databases
+aiosqlite

--- a/docs/backends/async.md
+++ b/docs/backends/async.md
@@ -1,0 +1,81 @@
+Asynchronous routes will be automatically generated when using the `DatabasesCRUDRouter`. To use it, you must pass a 
+[pydantic](https://pydantic-docs.helpmanual.io/) model, your SQLAlchemy Table, and the databases database. 
+This CRUDRouter is intended to be used with the python [Databases](https://www.encode.io/databases/) library. An example
+of how to use [Databases](https://www.encode.io/databases/) with FastAPI can be found both 
+[here](https://fastapi.tiangolo.com/advanced/async-sql-databases/) and below.
+
+!!! warning
+    To use the `DatabasesCRUDRouter`, Databases **and** SQLAlchemy must be first installed.
+
+## Minimal Example
+Below is a minimal example assuming that you have already imported and created 
+all the required models and database connections.
+
+```python
+router = DatabasesCRUDRouter(
+    database=my_database, 
+    table=my_table, 
+    model=MyPydanticModel, 
+    create_schema=MyPydanticCreateModel
+)
+app.include_router(router)
+```
+
+## Full Example
+```python
+import databases
+import sqlalchemy
+
+from pydantic import BaseModel
+from fastapi import FastAPI
+from fastapi_crudrouter import DatabasesCRUDRouter
+
+DATABASE_URL = "sqlite:///./test.db"
+
+database = databases.Database(DATABASE_URL)
+engine = sqlalchemy.create_engine(
+    DATABASE_URL, 
+    connect_args={"check_same_thread": False}
+)
+
+metadata = sqlalchemy.MetaData()
+potatoes =  sqlalchemy.Table(
+    "potatoes",
+    metadata,
+    sqlalchemy.Column("id",  sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column("thickness", sqlalchemy.Float),
+    sqlalchemy.Column("mass", sqlalchemy.Float),
+    sqlalchemy.Column("color", sqlalchemy.String),
+    sqlalchemy.Column("type", sqlalchemy.String),
+)
+metadata.create_all(bind=engine)
+
+
+class PotatoCreate(BaseModel):
+    thickness: float
+    mass: float
+    color: str
+    type: str
+
+class Potato(PotatoCreate):
+    id: int
+
+    
+app = FastAPI()
+
+@app.on_event("startup")
+async def startup():
+    await database.connect()
+
+@app.on_event("shutdown")
+async def shutdown():
+    await database.disconnect()
+
+router = DatabasesCRUDRouter(
+    database=database, 
+    table=potatoes, 
+    model=Potato, 
+    create_schema=PotatoCreate
+)
+app.include_router(router)
+```

--- a/docs/backends/memory.md
+++ b/docs/backends/memory.md
@@ -6,7 +6,7 @@ well suited for rapid bootstrapping and prototyping.
 ```python
 from pydantic import BaseModel
 from fastapi import FastAPI
-from fastapi_crudrouter import MemoryCRUDRouter as CRUDRouter
+from fastapi_crudrouter import MemoryCRUDRouter
 
 class Potato(BaseModel):
     id: int
@@ -14,7 +14,8 @@ class Potato(BaseModel):
     mass: float
 
 app = FastAPI()
-app.include_router(CRUDRouter(model=Potato))
+router = MemoryCRUDRouter(model=Potato)
+app.include_router(router)
 ```
 
 !!! warning

--- a/docs/backends/sqlalchemy.md
+++ b/docs/backends/sqlalchemy.md
@@ -34,8 +34,17 @@ from fastapi import FastAPI
 from fastapi_crudrouter import SQLAlchemyCRUDRouter
 
 app = FastAPI()
-engine = create_engine("sqlite:///./app.db", connect_args={"check_same_thread": False})
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+engine = create_engine(
+    "sqlite:///./app.db", 
+    connect_args={"check_same_thread": False}
+)
+
+SessionLocal = sessionmaker(
+    autocommit=False, 
+    autoflush=False, 
+    bind=engine
+)
+
 Base = declarative_base()
 
 def get_db():
@@ -68,6 +77,14 @@ class PotatoModel(Base):
     type = Column(String)
 
 Base.metadata.create_all(bind=engine)
-app.include_router(SQLAlchemyCRUDRouter(model=Potato, db_model=PotatoModel, db=get_db, create_schema=PotatoCreate, prefix='potato'))
 
+router = SQLAlchemyCRUDRouter(
+    model=Potato, 
+    db_model=PotatoModel, 
+    db=get_db, 
+    create_schema=PotatoCreate, 
+    prefix='potato'
+)
+
+app.include_router(router)
 ```

--- a/fastapi_crudrouter/__init__.py
+++ b/fastapi_crudrouter/__init__.py
@@ -1,1 +1,1 @@
-from .core import MemoryCRUDRouter, SQLAlchemyCRUDRouter
+from .core import MemoryCRUDRouter, SQLAlchemyCRUDRouter, DatabasesCRUDRouter

--- a/fastapi_crudrouter/core/__init__.py
+++ b/fastapi_crudrouter/core/__init__.py
@@ -2,3 +2,4 @@ from ._base import CRUDGenerator, NOT_FOUND
 
 from .mem import MemoryCRUDRouter
 from .sqlalchemy import SQLAlchemyCRUDRouter
+from .databases import DatabasesCRUDRouter

--- a/fastapi_crudrouter/core/databases.py
+++ b/fastapi_crudrouter/core/databases.py
@@ -1,0 +1,85 @@
+from typing import Callable
+from fastapi import Depends
+
+from . import CRUDGenerator, NOT_FOUND
+
+try:
+    from databases.core import Database
+except ImportError:
+    databases_installed = False
+else:
+    databases_installed = True
+
+
+class DatabasesCRUDRouter(CRUDGenerator):
+
+    def __init__(self, database, table, *args, **kwargs):
+        assert databases_installed, "Databases must be installed to use the DatabasesCRUDRouter."
+        self.db = database
+        self.table = table
+        self._pk = table.primary_key.columns.values()[0].name
+        self._pk_col = self.table.c[self._pk]
+
+        super().__init__(*args, **kwargs)
+
+    def _get_all(self) -> Callable:
+        async def route():
+            q = self.table.select()
+            return await self.db.fetch_all(q)
+
+        return route
+
+    def _get_one(self) -> Callable:
+        async def route(item_id):
+            q = self.table.select().where(self._pk_col == item_id)
+            model = await self.db.fetch_one(q)
+
+            if model:
+                return model
+            else:
+                raise NOT_FOUND
+
+        return route
+
+    def _create(self) -> Callable:
+        async def route(schema: self.create_schema):
+            q = self.table.insert()
+            rid = await self.db.execute(query=q, values=schema.dict())
+            return {**schema.dict(), self._pk: rid}
+
+        return route
+
+    def _update(self) -> Callable:
+        async def route(item_id: int, schema: self.model_cls):
+            q = self.table.update().where(self._pk_col == item_id)
+            rid = await self.db.execute(query=q, values=schema.dict(exclude={self._pk}))
+
+            if rid:
+                return {**schema.dict(), self._pk: rid}
+            else:
+                raise NOT_FOUND
+
+        return route
+
+    def _delete_all(self) -> Callable:
+        async def route():
+            q = self.table.delete()
+            await self.db.execute(query=q)
+
+            return await self._get_all()()
+
+        return route
+
+    def _delete_one(self) -> Callable:
+        async def route(item_id: int):
+            q = self.table.delete().where(self._pk_col == item_id)
+
+            row = await self._get_one()(item_id)
+            rid = await self.db.execute(query=q)
+
+            if rid:
+                return row
+            else:
+                raise NOT_FOUND
+
+        return route

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
 - Backends:
     - In Memory: backends/memory.md
     - SQLAlchemy: backends/sqlalchemy.md
+    - Databases (async): backends/async.md
 
 
 markdown_extensions:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='FastAPI-CRUDRouter',
-    version='0.1.2',
+    version='0.1.3',
     author='Adam Watkins',
     author_email='cadamrun@gmail.com',
     packages=find_packages(exclude=('tests', 'tests.implementations')),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,14 @@ from fastapi.testclient import TestClient
 
 from .implementations import *
 
+implementations = [
+    memory_implementation,
+    sqlalchemy_implementation,
+    databases_implementation
+]
 
-@pytest.fixture(params=[memory_implementation, sqlalchemy_implementation])
+
+@pytest.fixture(params=implementations)
 def client(request):
 
     yield TestClient(request.param())

--- a/tests/implementations/__init__.py
+++ b/tests/implementations/__init__.py
@@ -1,3 +1,4 @@
 from .memory import memory_implementation
 from .sqlalchemy_ import sqlalchemy_implementation, sqlalchemy_implementation_custom_ids
 from .overloaded import overloaded_app
+from .databases_ import databases_implementation

--- a/tests/implementations/databases_.py
+++ b/tests/implementations/databases_.py
@@ -1,0 +1,71 @@
+from typing import List
+
+import databases
+from sqlalchemy import MetaData, Table, Column, Integer, Float, String, create_engine
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+from sqlalchemy_utils import drop_database, create_database, database_exists
+
+from fastapi_crudrouter import DatabasesCRUDRouter
+from tests import Potato, PotatoCreate, Carrot, CarrotCreate
+
+DATABASE_URL = "sqlite:///./test.db"
+
+
+def _setup_database():
+    if database_exists(DATABASE_URL):
+        drop_database(DATABASE_URL)
+
+    create_database(DATABASE_URL)
+    database = databases.Database(DATABASE_URL)
+    engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+
+    return engine, database
+
+
+def databases_implementation():
+    engine, database = _setup_database()
+
+    metadata = MetaData()
+    potatoes = Table(
+        "potatoes",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("thickness", Float),
+        Column("mass", Float),
+        Column("color", String),
+        Column("type", String),
+    )
+    carrots = Table(
+        "carrots",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("length", Float),
+        Column("color", String),
+    )
+    metadata.create_all(bind=engine)
+
+    app = FastAPI()
+
+    @app.on_event("startup")
+    async def startup():
+        await database.connect()
+
+    @app.on_event("shutdown")
+    async def shutdown():
+        await database.disconnect()
+
+    potato_router = DatabasesCRUDRouter(database=database, table=potatoes, model=Potato, create_schema=PotatoCreate)
+    carrot_router = DatabasesCRUDRouter(database=database, table=carrots, model=Carrot, create_schema=CarrotCreate)
+    app.include_router(potato_router)
+    app.include_router(carrot_router)
+
+    return app
+
+
+if __name__ == '__main__':
+    import uvicorn
+    app = databases_implementation()
+
+    uvicorn.run(app)


### PR DESCRIPTION
Added async / python database support with the new DatabasesCRUDRouter

## Minimal Example
Below is a minimal example assuming that you have already imported and created 
all the required models and database connections.

```python
router = DatabasesCRUDRouter(
    database=my_database, 
    table=my_table, 
    model=MyPydanticModel, 
    create_schema=MyPydanticCreateModel
)
app.include_router(router)
```

## Full Example
```python
import databases
import sqlalchemy
from pydantic import BaseModel
from fastapi import FastAPI
from fastapi_crudrouter import DatabasesCRUDRouter
DATABASE_URL = "sqlite:///./test.db"
database = databases.Database(DATABASE_URL)
engine = sqlalchemy.create_engine(
    DATABASE_URL, 
    connect_args={"check_same_thread": False}
)
metadata = sqlalchemy.MetaData()
potatoes =  sqlalchemy.Table(
    "potatoes",
    metadata,
    sqlalchemy.Column("id",  sqlalchemy.Integer, primary_key=True),
    sqlalchemy.Column("thickness", sqlalchemy.Float),
    sqlalchemy.Column("mass", sqlalchemy.Float),
    sqlalchemy.Column("color", sqlalchemy.String),
    sqlalchemy.Column("type", sqlalchemy.String),
)
metadata.create_all(bind=engine)
class PotatoCreate(BaseModel):
    thickness: float
    mass: float
    color: str
    type: str
class Potato(PotatoCreate):
    id: int
    
app = FastAPI()
@app.on_event("startup")
async def startup():
    await database.connect()
@app.on_event("shutdown")
async def shutdown():
    await database.disconnect()
router = DatabasesCRUDRouter(
    database=database, 
    table=potatoes, 
    model=Potato, 
    create_schema=PotatoCreate
)
app.include_router(router)
```