### PR TITLE
6 exclude

### DIFF
--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -1,4 +1,5 @@
-Should you need to add custom functionality to any of your routes any of the included routers allows you to do so.
+Should you need to add custom functionality to any of your routes any of the included routers allows you to do so. 
+Should you wish to disable a route from being generated, it can be done [here](../routing/#disabling-routes).
 
 ## Overriding
 Routes in the CRUDRouter can be overridden by using the standard fastapi route decorators. These include:

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,14 +1,14 @@
 ## Default Routes
 By default, the CRUDRouter will generate the six routes below for you. 
 
-| Route        | Method   | Description |
-| ------------ | -------- | ----------- |
-| `/`          | `GET`    | Get all the resources |
-| `/`          | `POST`   | Create a new resource |
-| `/`          | `DELETE` | Delete all the resources|
-| `/{item_id}` | `GET`    | Get an existing resource matching the given `item_id` |
-| `/{item_id}` | `PUT`    | Update an existing resource matching the given `item_id`  |
-| `/{item_id}` | `DELETE` | Delete an existing resource matching the given `item_id` |
+| Route        | Method   | Description
+| ------------ | -------- | ----
+| `/`          | `GET`    | Get all the resources 
+| `/`          | `POST`   | Create a new resource 
+| `/`          | `DELETE` | Delete all the resources
+| `/{item_id}` | `GET`    | Get an existing resource matching the given `item_id`
+| `/{item_id}` | `PUT`    | Update an existing resource matching the given `item_id`
+| `/{item_id}` | `DELETE` | Delete an existing resource matching the given `item_id`
 
 !!! note "Route URLs"
     Note that the route url is prefixed by the defined prefix.
@@ -26,4 +26,14 @@ the [SQLAlchemyCRUDRouter](backends/sqlalchemy.md) will use the model's table na
     `router = CRUDRouter(model=mymodel, prefix='carrot')`
 
 ## Disabling Routes
-This feature has not been implemented yet. For now, a workaround is overriding your routes so they do nothing. 
+Routes can be disabled from generating with a key word argument (kwarg) when creating your CRUDRouter. The valid kwargs 
+are shown below.
+
+| Argument         | Default | Description 
+| ---------------- | ------  | ---
+| get_all_route    | True    | Setting this to false will prevent the get all route from generating
+| get_one_route    | True    | Setting this to false will prevent the get one route from generating
+| delete_all_route | True    | Setting this to false will prevent the delete all route from generating
+| delete_one_route | True    | Setting this to false will prevent the delete one route from generating
+| create_route     | True    | Setting this to false will prevent the create route from generating
+| update_route     | True    | Setting this to false will prevent the update route from generating

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -37,3 +37,8 @@ are shown below.
 | delete_one_route | True    | Setting this to false will prevent the delete one route from generating
 | create_route     | True    | Setting this to false will prevent the create route from generating
 | update_route     | True    | Setting this to false will prevent the update route from generating
+
+As an example, the *delete all* route can be disabled by doing the following:
+```python
+router = MemmoryCRUDRouter(model=MyModel, deleta_all_route=False)
+```

--- a/fastapi_crudrouter/core/_base.py
+++ b/fastapi_crudrouter/core/_base.py
@@ -13,20 +13,46 @@ class CRUDGenerator(APIRouter):
     model_cls: BaseModel = None
     _base_path: str = '/'
 
-    def __init__(self, model: BaseModel, create_schema: BaseModel = None, prefix: str = None, *args, **kwargs):
+    def __init__(
+        self,
+        model:
+        BaseModel,
+        create_schema:
+        BaseModel = None,
+        prefix: str = None,
+        get_all_route: bool = True,
+        get_one_route: bool = True,
+        create_route: bool = True,
+        update_route: bool = True,
+        delete_one_route: bool = True,
+        delete_all_route: bool = True,
+        *args,
+        **kwargs
+    ) -> APIRouter:
+
         self.model_cls = model
         self.create_schema = create_schema
 
         prefix = self._base_path + (self.model_cls.__name__.lower() if not prefix else prefix).strip('/')
         super().__init__(prefix=prefix, tags=[prefix.strip('/').capitalize()], *args, **kwargs)
 
-        super().add_api_route('', self._get_all(), methods=['GET'], response_model=Optional[List[self.model_cls]], summary='Get All')
-        super().add_api_route('', self._create(), methods=['POST'], response_model=self.model_cls, summary='Create One')
-        super().add_api_route('', self._delete_all(), methods=['DELETE'], response_model=Optional[List[self.model_cls]], summary='Delete All')
+        if get_all_route:
+            super().add_api_route('', self._get_all(), methods=['GET'], response_model=Optional[List[self.model_cls]], summary='Get All')
 
-        super().add_api_route('/{item_id}', self._get_one(), methods=['GET'], response_model=self.model_cls, summary='Get One')
-        super().add_api_route('/{item_id}', self._update(), methods=['PUT'], response_model=self.model_cls, summary='Update One')
-        super().add_api_route('/{item_id}', self._delete_one(), methods=['DELETE'], response_model=self.model_cls, summary='Delete All')
+        if create_route:
+            super().add_api_route('', self._create(), methods=['POST'], response_model=self.model_cls, summary='Create One')
+
+        if delete_all_route:
+            super().add_api_route('', self._delete_all(), methods=['DELETE'], response_model=Optional[List[self.model_cls]], summary='Delete All')
+
+        if get_one_route:
+            super().add_api_route('/{item_id}', self._get_one(), methods=['GET'], response_model=self.model_cls, summary='Get One')
+
+        if update_route:
+            super().add_api_route('/{item_id}', self._update(), methods=['PUT'], response_model=self.model_cls, summary='Update One')
+
+        if delete_one_route:
+            super().add_api_route('/{item_id}', self._delete_one(), methods=['DELETE'], response_model=self.model_cls, summary='Delete All')
 
     def api_route(self, path: str, *args, **kwargs):
         """ Overrides and exiting route if it exists"""

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -1,0 +1,50 @@
+import random
+import pytest
+
+from fastapi import FastAPI, testclient
+from fastapi_crudrouter import MemoryCRUDRouter
+
+from tests import Potato
+
+URL = '/potato'
+
+
+def get_client(**kwargs):
+    app = FastAPI()
+    app.include_router(MemoryCRUDRouter(model=Potato, prefix=URL, **kwargs))
+
+    return testclient.TestClient(app)
+
+
+@pytest.mark.parametrize('i', list(range(1, len(MemoryCRUDRouter.get_routes()) + 1)))
+def test_exclude_internal(i):
+    keys = random.sample(MemoryCRUDRouter.get_routes(), k=i)
+    kwargs = {r + '_route': False for r in keys}
+
+    router = MemoryCRUDRouter(model=Potato, prefix=URL, **kwargs)
+    assert len(router.routes) == len(MemoryCRUDRouter.get_routes()) - i
+
+
+def test_exclude_delete_all():
+    client = get_client(delete_all_route=False)
+    assert client.delete(URL).status_code == 405
+    assert client.get(URL).status_code == 200
+
+
+def test_exclude_all():
+    routes = MemoryCRUDRouter.get_routes()
+    kwargs = {r + '_route': False for r in routes}
+    client = get_client(**kwargs)
+
+    assert client.delete(URL).status_code == 404
+    assert client.get(URL).status_code == 404
+    assert client.post(URL).status_code == 404
+    assert client.put(URL).status_code == 404
+
+    for id_ in [-1, 1, 0, 14]:
+        assert client.get(f'{URL}/{id_}').status_code == 404
+        assert client.post(f'{URL}/{id_}').status_code == 404
+        assert client.put(f'{URL}/{id_}').status_code == 404
+        assert client.delete(f'{URL}/{id_}').status_code == 404
+
+


### PR DESCRIPTION
Routes can be disabled from generating with a key word argument (kwarg) when creating your CRUDRouter. The valid kwargs 
are shown below.

| Argument         | Default | Description 
| ---------------- | ------  | ---
| get_all_route    | True    | Setting this to false will prevent the get all route from generating
| get_one_route    | True    | Setting this to false will prevent the get one route from generating
| delete_all_route | True    | Setting this to false will prevent the delete all route from generating
| delete_one_route | True    | Setting this to false will prevent the delete one route from generating
| create_route     | True    | Setting this to false will prevent the create route from generating
| update_route     | True    | Setting this to false will prevent the update route from generating

As an example, the *delete all* route can be disabled by doing the following:
```python
router = MemmoryCRUDRouter(model=MyModel, deleta_all_route=False)
```