### PR TITLE
📝 fix outdated basic example in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ class Potato(BaseModel):
     mass: float
 
 app = FastAPI()
-app.include_router(CRUDRouter(model=Potato))
+app.include_router(CRUDRouter(schema=Potato))
 ```
 
 ## OpenAPI Support


### PR DESCRIPTION
Existing example shows the following:
```app.include_router(CRUDRouter(schema=Potato))```
which cause the following error, because the memory router takes `schema` as a kwarg, not `model`:
```TypeError: __init__() missing 1 required positional argument: 'schema'```