### PR TITLE
Table type needs to be visible even if Databases not installed

### DIFF
--- a/fastapi_crudrouter/core/databases.py
+++ b/fastapi_crudrouter/core/databases.py
@@ -6,11 +6,11 @@ from . import CRUDGenerator, NOT_FOUND
 
 try:
    from sqlalchemy.sql.schema import Table
-    from databases.core import Database
+   from databases.core import Database
 except ImportError:
-    databases_installed = False
+   databases_installed = False
 else:
-    databases_installed = True
+   databases_installed = True
 
 
 class DatabasesCRUDRouter(CRUDGenerator):

--- a/fastapi_crudrouter/core/databases.py
+++ b/fastapi_crudrouter/core/databases.py
@@ -1,12 +1,12 @@
 from typing import Callable
 from fastapi import Depends
 from pydantic import BaseModel
+from sqlalchemy.sql.schema import Table
 
 from . import CRUDGenerator, NOT_FOUND
 
 try:
     from databases.core import Database
-    from sqlalchemy.sql.schema import Table
 except ImportError:
     databases_installed = False
 else:

--- a/fastapi_crudrouter/core/databases.py
+++ b/fastapi_crudrouter/core/databases.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 from . import CRUDGenerator, NOT_FOUND
 
 try:
+   from sqlalchemy.sql.schema import Table
     from databases.core import Database
 except ImportError:
     databases_installed = False

--- a/fastapi_crudrouter/core/databases.py
+++ b/fastapi_crudrouter/core/databases.py
@@ -1,7 +1,6 @@
 from typing import Callable
 from fastapi import Depends
 from pydantic import BaseModel
-from sqlalchemy.sql.schema import Table
 
 from . import CRUDGenerator, NOT_FOUND
 


### PR DESCRIPTION
Great project! I'm happy to report I was able to drop it in along with https://github.com/tiangolo/pydantic-sqlalchemy and it plays nicely with the generated Pydantic models.

That said, I ran into an issue where I had to install `Databases` in my project to be able to import any code from your package, even though I don't care about the databases connector (just using SQLAlchemy).

```
fastapi_1  |   File "./main.py", line 6, in <module>
fastapi_1  |     from fastapi_crudrouter import SQLAlchemyCRUDRouter as CRUDRouter
fastapi_1  |   File "/usr/local/lib/python3.8/site-packages/fastapi_crudrouter/__init__.py", line 1, in <module>
fastapi_1  |     from .core import MemoryCRUDRouter, SQLAlchemyCRUDRouter, DatabasesCRUDRouter
fastapi_1  |   File "/usr/local/lib/python3.8/site-packages/fastapi_crudrouter/core/__init__.py", line 5, in <module>
fastapi_1  |     from .databases import DatabasesCRUDRouter
fastapi_1  |   File "/usr/local/lib/python3.8/site-packages/fastapi_crudrouter/core/databases.py", line 16, in <module>
fastapi_1  |     class DatabasesCRUDRouter(CRUDGenerator):
fastapi_1  |   File "/usr/local/lib/python3.8/site-packages/fastapi_crudrouter/core/databases.py", line 18, in DatabasesCRUDRouter
fastapi_1  |     def __init__(self, schema: BaseModel, table: Table, database: Database, *args, **kwargs):
fastapi_1  | NameError: name 'Table' is not defined
```

Importing `SQLAlchemyCRUDRouter` ends up looking at the overall package `fastapi_crudrouter` which ends up looking at that `from .core import...` etc. etc. until it hits `DatabasesCRUDRouter`.

Then, the try/except for importing `Databases` works as expected, *but* the import for the `Table` type is also in that block. It's missing, but the rest of the code is still executing, and so it fails as not defined.

This is the simplest/most direct fix, but you could also change the overall `from .core import ...` model if you want.

Thanks again!