### PR TITLE
Allow arbitrary ID keys for _update and _delete_one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,3 @@ venv.bak/
 
 # Databases
 *.db
-
-# IDEs
-.idea

--- a/fastapi_crudrouter/core/_base.py
+++ b/fastapi_crudrouter/core/_base.py
@@ -17,6 +17,7 @@ class CRUDGenerator(APIRouter):
         self,
         schema: BaseModel,
         create_schema: BaseModel = None,
+        update_schema: BaseModel = None,
         prefix: str = None,
         get_all_route: bool = True,
         get_one_route: bool = True,
@@ -30,6 +31,7 @@ class CRUDGenerator(APIRouter):
 
         self.schema = schema
         self.create_schema = create_schema if create_schema else self.schema_factory(self.schema)
+        self.update_schema = update_schema if update_schema else self.schema_factory(self.schema)
 
         prefix = self._base_path + (self.schema.__name__.lower() if not prefix else prefix).strip('/')
         super().__init__(prefix=prefix, tags=[prefix.strip('/').capitalize()], *args, **kwargs)

--- a/fastapi_crudrouter/core/databases.py
+++ b/fastapi_crudrouter/core/databases.py
@@ -60,7 +60,7 @@ class DatabasesCRUDRouter(CRUDGenerator):
         return route
 
     def _update(self) -> Callable:
-        async def route(item_id: int, schema: self.schema):
+        async def route(item_id: int, schema: self.update_schema):
             q = self.table.update().where(self._pk_col == item_id)
             rid = await self.db.execute(query=q, values=schema.dict(exclude={self._pk}))
 

--- a/fastapi_crudrouter/core/mem.py
+++ b/fastapi_crudrouter/core/mem.py
@@ -36,7 +36,7 @@ class MemoryCRUDRouter(CRUDGenerator):
         return route
 
     def _update(self) -> Callable:
-        def route(item_id: int, model: self.schema):
+        def route(item_id: int, model: self.update_schema):
             for i, m in enumerate(self.models):
                 if m.id == item_id:
                     model.id = m.id

--- a/fastapi_crudrouter/core/sqlalchemy.py
+++ b/fastapi_crudrouter/core/sqlalchemy.py
@@ -62,7 +62,7 @@ class SQLAlchemyCRUDRouter(CRUDGenerator):
         return route
 
     def _update(self) -> Callable:
-        def route(item_id: int, model: self.schema, db: Session = Depends(self.db_func)):
+        def route(item_id, model: self.schema, db: Session = Depends(self.db_func)):
             db_model = self._get_one()(item_id, db)
 
             for key, value in model.dict(exclude={self._primary_key}).items():
@@ -86,7 +86,7 @@ class SQLAlchemyCRUDRouter(CRUDGenerator):
         return route
 
     def _delete_one(self) -> Callable:
-        def route(item_id: int, db: Session = Depends(self.db_func)):
+        def route(item_id, db: Session = Depends(self.db_func)):
             db_model = self._get_one()(item_id, db)
             db.delete(db_model)
             db.commit()

--- a/fastapi_crudrouter/core/sqlalchemy.py
+++ b/fastapi_crudrouter/core/sqlalchemy.py
@@ -62,7 +62,7 @@ class SQLAlchemyCRUDRouter(CRUDGenerator):
         return route
 
     def _update(self) -> Callable:
-        def route(item_id, model: self.schema, db: Session = Depends(self.db_func)):
+        def route(item_id, model: self.update_schema, db: Session = Depends(self.db_func)):
             db_model = self._get_one()(item_id, db)
 
             for key, value in model.dict(exclude={self._primary_key}).items():


### PR DESCRIPTION
Same as `_create`, allows SQLAlchemy primary keys of types other than `Integer` (such as `UUID`).