### PR TITLE
Expose base_path as optional config (to facilitate api versioning)

### DIFF
--- a/docs/en/docs/routing.md
+++ b/docs/en/docs/routing.md
@@ -18,6 +18,10 @@ By default, the CRUDRouter will generate the six routes below for you.
 
     **Example:** If the CRUDRouter's prefix is set as *potato* and I want to update a specific potato the route I want to access is
     `/potato/my_potato_id` where *my_potato_id* is the ID of the potato.
+    
+!!! tip "Custom Base Path"
+    You are also able to set a custom base path (instead of `/`) with the optional `base_path` kwarg when creating your CRUDRouter.
+    This can be done like so: `router = CRUDRouter(model=mymodel, base_path='/api/v1/')`
 
 ## Prefixes
 Depending on which CRUDRouter you are using, the CRUDRouter will try to automatically generate a suitable prefix for your

--- a/fastapi_crudrouter/core/_base.py
+++ b/fastapi_crudrouter/core/_base.py
@@ -11,13 +11,13 @@ NOT_FOUND = HTTPException(404, 'Item not found')
 
 class CRUDGenerator(APIRouter):
     schema: BaseModel = None
-    _base_path: str = '/'
 
     def __init__(
         self,
         schema: BaseModel,
         create_schema: BaseModel = None,
         prefix: str = None,
+        base_path: str = '/',
         get_all_route: bool = True,
         get_one_route: bool = True,
         create_route: bool = True,
@@ -29,9 +29,10 @@ class CRUDGenerator(APIRouter):
     ):
 
         self.schema = schema
+        self.base_path = base_path
         self.create_schema = create_schema if create_schema else self.schema_factory(self.schema)
 
-        prefix = self._base_path + (self.schema.__name__.lower() if not prefix else prefix).strip('/')
+        prefix = self.base_path + (self.schema.__name__.lower() if not prefix else prefix).strip('/')
         super().__init__(prefix=prefix, tags=[prefix.strip('/').capitalize()], *args, **kwargs)
 
         if get_all_route:


### PR DESCRIPTION
Facilitate optionally overriding base_path without monkey-patching. Use case is if you want to prefix your paths (e.g. `/api/v{version_#}/`). It could of course be hacked in w/prefix as well, but this feels more consistent when you have multiple routers (still lets their prefix be default named after their entity).