### PR TITLE
:bug: No prefixing below fastapi v0.62 #29

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-fastapi
+fastapi>=0.62.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '0.4.0'
+VERSION = '0.4.1'
 
 setup(
     name='fastapi-crudrouter',


### PR DESCRIPTION
closes #29

APIRouter prefixing is not available below fastapi version 0.62. This is a hotfix until custom prefixing support for previous versions of fastapi can be implemented