### PR TITLE
Add missing IntegrityError import

### DIFF
--- a/fastapi_crudrouter/core/sqlalchemy.py
+++ b/fastapi_crudrouter/core/sqlalchemy.py
@@ -8,6 +8,7 @@ from . import CRUDGenerator, NOT_FOUND, utils
 try:
     from sqlalchemy.orm import Session
     from sqlalchemy.ext.declarative import DeclarativeMeta
+    from sqlalchemy.exc import IntegrityError
 except ImportError:
     sqlalchemy_installed = False
     Session = None

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '0.4.2'
+VERSION = '0.4.3'
 
 setup(
     name='fastapi-crudrouter',

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -16,12 +16,12 @@ def test_get(client, url: str = URL):
     assert type(data) == list and len(data) == 0
 
 
-def test_post(client, url: str = URL, model: BaseModel = basic_potato):
+def test_post(client, url: str = URL, model: BaseModel = basic_potato, expected_length: int = 1):
     res = client.post(url, json=model.dict())
     assert res.status_code == 200, res.json()
 
     data = client.get(url).json()
-    assert len(data) == 1
+    assert len(data) == expected_length
 
 
 def test_get_one(client, url: str = URL, model: BaseModel = basic_potato, id_key: str = 'id'):

--- a/tests/test_sqlalchemy_router.py
+++ b/tests/test_sqlalchemy_router.py
@@ -49,10 +49,10 @@ def test_integrity_error():
 
     args = client, '/potato', potato
     test_router.test_post(*args)
-    with pytest.raises(IntegrityError):
+    with pytest.raises(AssertionError):
         test_router.test_post(*args)
 
     # No integrity error here because of the create_schema
     args = client, '/carrot', Carrot(id=1, length=2, color='red')
     test_router.test_post(*args)
-    test_router.test_post(*args)
+    test_router.test_post(*args, expected_length=2)


### PR DESCRIPTION
Missing `IntegrityError` import causes `_create` to skip rolling back in case of issues.