### PR TITLE
Allow CRUDGenerator to accept optional tags argument

### DIFF
--- a/fastapi_crudrouter/core/_base.py
+++ b/fastapi_crudrouter/core/_base.py
@@ -48,9 +48,10 @@ class CRUDGenerator(Generic[T], APIRouter):
 
         prefix = str(self.schema.__name__.lower() if not prefix else prefix)
         prefix = self._base_path + prefix.strip("/")
-        super().__init__(
-            prefix=prefix, tags=[prefix.strip("/").capitalize()], *args, **kwargs
+        tags = (
+            [prefix.strip("/").capitalize()] if "tags" not in kwargs else kwargs["tags"]
         )
+        super().__init__(prefix=prefix, tags=tags, *args, **kwargs)
 
         if get_all_route:
             super().add_api_route(

--- a/fastapi_crudrouter/core/_base.py
+++ b/fastapi_crudrouter/core/_base.py
@@ -49,7 +49,7 @@ class CRUDGenerator(Generic[T], APIRouter):
         prefix = str(self.schema.__name__.lower() if not prefix else prefix)
         prefix = self._base_path + prefix.strip("/")
         tags = (
-            [prefix.strip("/").capitalize()] if "tags" not in kwargs else kwargs["tags"]
+            [prefix.strip("/").capitalize()] if "tags" not in kwargs else kwargs.pop("tags")
         )
         super().__init__(prefix=prefix, tags=tags, *args, **kwargs)
 


### PR DESCRIPTION
Hi, I made a small change to allow `CRUDGenerator` to accept a tags argument like its base class `APIRouter` does.  If no tags argument is provided, then the behavior is like before.