### PR TITLE
[WIP] Fix Tortoise not populating nested models

### DIFF
--- a/fastapi_crudrouter/core/tortoise.py
+++ b/fastapi_crudrouter/core/tortoise.py
@@ -5,27 +5,30 @@ from ._types import DEPENDENCIES, PAGINATION, PYDANTIC_SCHEMA
 
 try:
     from tortoise.models import Model
+    from tortoise.contrib.pydantic.base import PydanticModel as TORTOISE_SCHEMA
 except ImportError:
-    Model: Any = None  # type: ignore
     tortoise_installed = False
+
+    class TORTOISE_SCHEMA(PYDANTIC_SCHEMA):
+        pass
+
+
 else:
     tortoise_installed = True
 
-from tortoise.contrib.pydantic.base import PydanticModel as TORTOISE_SCHEMA
+SCHEMA = Union["TORTOISE_SCHEMA", "PYDANTIC_SCHEMA"]
 
-CALLABLE = Callable[..., Coroutine[Any, Any, Model]]
-CALLABLE_LIST = Callable[..., Coroutine[Any, Any, List[Model]]]
-
-# TODO: Change TORTOISE_SCHEMA to include both TORTOISE_ORM and PYDANTIC schemas
+CALLABLE = Callable[..., Coroutine[Any, Any, "Model"]]
+CALLABLE_LIST = Callable[..., Coroutine[Any, Any, List["Model"]]]
 
 
-class TortoiseCRUDRouter(CRUDGenerator[TORTOISE_SCHEMA]):
+class TortoiseCRUDRouter(CRUDGenerator[SCHEMA]):
     def __init__(
         self,
-        schema: Type[TORTOISE_SCHEMA],
-        db_model: Type[Model],
-        create_schema: Optional[Type[TORTOISE_SCHEMA]] = None,
-        update_schema: Optional[Type[TORTOISE_SCHEMA]] = None,
+        schema: Type[SCHEMA],
+        db_model: Type["Model"],
+        create_schema: Optional[Type[SCHEMA]] = None,
+        update_schema: Optional[Type[SCHEMA]] = None,
         prefix: Optional[str] = None,
         tags: Optional[List[str]] = None,
         paginate: Optional[int] = None,
@@ -61,45 +64,72 @@ class TortoiseCRUDRouter(CRUDGenerator[TORTOISE_SCHEMA]):
         )
 
     def _get_all(self, *args: Any, **kwargs: Any) -> CALLABLE_LIST:
-        async def route(pagination: PAGINATION = self.pagination) -> List[Model]:
-            skip, limit = pagination.get("skip"), pagination.get("limit")
-            query = self.db_model.all().offset(cast(int, skip))
-            if limit:
-                query = query.limit(limit)
-            if issubclass(self.schema, TORTOISE_SCHEMA):
+        if issubclass(self.schema, TORTOISE_SCHEMA):
+
+            async def route(
+                pagination: PAGINATION = self.pagination,
+            ) -> List[self.schema]:
+                skip, limit = pagination.get("skip"), pagination.get("limit")
+                query = self.db_model.all().offset(cast(int, skip))
+                if limit:
+                    query = query.limit(limit)
                 return await self.schema.from_queryset(query)
-            return await query
+
+        else:
+
+            async def route(pagination: PAGINATION = self.pagination) -> List["Model"]:
+                skip, limit = pagination.get("skip"), pagination.get("limit")
+                query = self.db_model.all().offset(cast(int, skip))
+                if limit:
+                    query = query.limit(limit)
+                return await query
 
         return route
 
     def _get_one(self, *args: Any, **kwargs: Any) -> CALLABLE:
-        async def route(item_id: int) -> Model:
-            model = await self.db_model.filter(id=item_id).first()
+        if issubclass(self.schema, TORTOISE_SCHEMA):
 
-            if not model:
-                raise NOT_FOUND
+            async def route(item_id: int) -> self.schema:
+                model = await self.db_model.filter(id=item_id).first()
 
-            if issubclass(self.schema, TORTOISE_SCHEMA):
+                if not model:
+                    raise NOT_FOUND
+
                 return await self.schema.from_tortoise_orm(model)
-            return model
+
+        else:
+
+            async def route(item_id: int) -> "Model":
+                model = await self.db_model.filter(id=item_id).first()
+
+                if not model:
+                    raise NOT_FOUND
+
+                return model
 
         return route
 
     def _create(self, *args: Any, **kwargs: Any) -> CALLABLE:
-        async def route(model: self.create_schema) -> Model:  # type: ignore
-            db_model = self.db_model(**model.dict())
-            await db_model.save()
+        if issubclass(self.schema, TORTOISE_SCHEMA):
 
-            if issubclass(self.schema, TORTOISE_SCHEMA):
+            async def route(model: self.create_schema) -> self.schema:  # type: ignore
+                db_model = self.db_model(**model.dict())
+                await db_model.save()
                 return await self.schema.from_tortoise_orm(db_model)
-            return db_model
+
+        else:
+
+            async def route(model: self.create_schema) -> "Model":  # type: ignore
+                db_model = self.db_model(**model.dict())
+                await db_model.save()
+                return db_model
 
         return route
 
     def _update(self, *args: Any, **kwargs: Any) -> CALLABLE:
         async def route(
             item_id: int, model: self.update_schema  # type: ignore
-        ) -> Model:
+        ) -> Union["Model", self.schema]:
             await self.db_model.filter(id=item_id).update(
                 **model.dict(exclude_unset=True)
             )
@@ -108,15 +138,15 @@ class TortoiseCRUDRouter(CRUDGenerator[TORTOISE_SCHEMA]):
         return route
 
     def _delete_all(self, *args: Any, **kwargs: Any) -> CALLABLE_LIST:
-        async def route() -> List[Model]:
+        async def route() -> List[self.schema]:
             await self.db_model.all().delete()
             return await self._get_all()(pagination={"skip": 0, "limit": None})
 
         return route
 
     def _delete_one(self, *args: Any, **kwargs: Any) -> CALLABLE:
-        async def route(item_id: int) -> Model:
-            model: Model = await self._get_one()(item_id)
+        async def route(item_id: int) -> self.schema:
+            model: "Model" = await self._get_one()(item_id)
             await self.db_model.filter(id=item_id).delete()
 
             return model

--- a/tests/implementations/__init__.py
+++ b/tests/implementations/__init__.py
@@ -26,8 +26,14 @@ implementations = [
 ]
 
 try:
-    from .tortoise_ import tortoise_implementation
+    from .tortoise_ import (
+        tortoise_implementation,
+        tortoise_implementation_no_init,
+        tortoise_implementation_init,
+    )
 except ImportError:
     pass
 else:
     implementations.append(tortoise_implementation)
+    implementations.append(tortoise_implementation_no_init)
+    implementations.append(tortoise_implementation_init)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -21,7 +21,8 @@ def test_get(client, url: str = URL, params: dict = None, expected_length: int =
 def test_post(
     client, url: str = URL, model: Dict = None, expected_length: int = 1
 ) -> dict:
-    model = model or basic_potato
+    if model is None:
+        model = basic_potato
     res = client.post(url, json=model)
     assert res.status_code == 200, res.json()
 

--- a/tests/test_tortoise_nested_.py
+++ b/tests/test_tortoise_nested_.py
@@ -1,0 +1,207 @@
+from types import SimpleNamespace
+
+from tortoise.contrib.pydantic.creator import pydantic_model_creator
+from tortoise.exceptions import IntegrityError
+from tests.conftest import yield_test_client
+from typing import List
+
+import pytest
+from fastapi_crudrouter.core.tortoise import TortoiseCRUDRouter
+from pydantic import BaseModel
+from tortoise import Tortoise, Model, fields
+
+from tests import ORMModel, test_router
+from tests.implementations.tortoise_ import _setup_base_app, Parent, Child
+from tests.implementations import tortoise_
+from pydantic import ValidationError
+
+CHILD_URL = "/child"
+PARENT_URL = "/parent"
+
+
+TORTOISE_ORM = {
+    "connections": {"default": "sqlite://:memory:"},
+    "apps": {
+        "models": {
+            "models": ["tests.test_tortoise_nested_"],
+        },
+    },
+}
+
+
+# Schemas created in the module body, before Tortoise has initiated
+ChildNoInitSchema = pydantic_model_creator(Child, name="ChildNoInitSchema")
+ChildNoInitCreate = pydantic_model_creator(
+    Child, name="ChildNoInitCreate", exclude_readonly=True
+)
+ParentNoInitSchema = pydantic_model_creator(
+    Parent, name="ParentNoInitSchema", exclude=("age",)
+)
+ParentNoInitCreate = pydantic_model_creator(
+    Parent, name="ParentNoInitCreate", exclude_readonly=True, exclude=("age",)
+)
+
+
+def base_schemas():
+    class ChildSchema(ORMModel):
+        parent_id: int
+
+    class ChildCreate(BaseModel):
+        parent_id: int
+
+    class ParentSchema(ORMModel):
+        children: List[ChildSchema] = []
+
+    class ParentCreate(BaseModel):
+        pass
+
+    print(ParentCreate.schema_json(indent=2))
+
+    return ChildSchema, ChildCreate, ParentSchema, ParentCreate
+
+
+def tortoise_init_schemas():
+    Tortoise.init_models([tortoise_], "models")
+    ChildSchema = pydantic_model_creator(
+        Child, name="ChildSchemaInit", exclude=("parent", "parent_id")
+    )
+    ChildCreate = pydantic_model_creator(
+        Child, name="ChildCreateInit", exclude_readonly=True
+    )
+    ParentSchema = pydantic_model_creator(
+        Parent, name="ParentSchemaInit", exclude=("age",)
+    )
+    ParentCreate = pydantic_model_creator(
+        Parent, name="ParentCreateInit", exclude_readonly=True, exclude=("age",)
+    )
+
+    return ChildSchema, ChildCreate, ParentSchema, ParentCreate
+
+
+def tortoise_no_init_schemas():
+    return ChildNoInitSchema, ChildNoInitCreate, ParentNoInitSchema, ParentNoInitCreate
+
+
+async def on_startup():
+    await Tortoise.init(config=TORTOISE_ORM)
+    await Tortoise.generate_schemas()
+
+
+async def on_shutdown():
+    await Tortoise.close_connections()
+
+
+@pytest.fixture
+def tortoise_client():
+    ns = SimpleNamespace()
+    ns.__name__ = "tests.implementations.tortoise_"
+    app = _setup_base_app()
+    for c in yield_test_client(app, ns):
+        yield app, c
+
+
+def test_nested_models_pydantic_schemas(tortoise_client):
+    """
+    Tortoise will not fetch the related fields (Parent -> Child) automatically,
+    therefore the data for the children will be missing.
+    """
+    app, client = tortoise_client
+    ChildSchema, ChildCreate, ParentSchema, ParentCreate = base_schemas()
+
+    app.include_router(
+        TortoiseCRUDRouter(
+            schema=ParentSchema,
+            create_schema=ParentCreate,
+            db_model=Parent,
+            prefix=PARENT_URL,
+        )
+    )
+    app.include_router(
+        TortoiseCRUDRouter(
+            schema=ChildSchema,
+            create_schema=ChildCreate,
+            db_model=Child,
+            prefix=CHILD_URL,
+        )
+    )
+
+    with pytest.raises(ValidationError):
+        test_router.test_post(client, PARENT_URL, dict())
+
+
+def test_nested_models_tortoise_no_init(tortoise_client):
+    """
+    Pydantic models created with pydantic_model_creator, with models that where not
+    initiated will not have the relations mapped, therefore the parent_id field in
+    the Child, neither the Parent will have a children field in its model
+    """
+    app, client = tortoise_client
+    ChildSchema, ChildCreate, ParentSchema, ParentCreate = tortoise_no_init_schemas()
+
+    app.include_router(
+        TortoiseCRUDRouter(
+            schema=ParentSchema,
+            create_schema=ParentCreate,
+            db_model=Parent,
+            prefix=PARENT_URL,
+        )
+    )
+    app.include_router(
+        TortoiseCRUDRouter(
+            schema=ChildSchema,
+            create_schema=ChildCreate,
+            db_model=Child,
+            prefix=CHILD_URL,
+        )
+    )
+
+    parent = test_router.test_post(client, PARENT_URL, dict())
+    with pytest.raises(IntegrityError):
+        test_router.test_post(client, CHILD_URL, dict(parent_id=parent["id"]))
+
+    res = client.get(f'{PARENT_URL}/{parent["id"]}')
+    assert res.status_code == 200, res.json()
+    parent_data = res.json()
+
+    with pytest.raises(KeyError):
+        type(parent_data["children"])
+
+
+def test_nested_models_tortoise(tortoise_client):
+    """
+    Pydantic models created with pydantic_model_creator where the models already
+    have been initiated should return the models populated with its related objects
+    """
+    app, client = tortoise_client
+    ChildSchema, ChildCreate, ParentSchema, ParentCreate = tortoise_init_schemas()
+
+    app.include_router(
+        TortoiseCRUDRouter(
+            schema=ParentSchema,
+            create_schema=ParentCreate,
+            db_model=Parent,
+            prefix=PARENT_URL,
+        )
+    )
+    app.include_router(
+        TortoiseCRUDRouter(
+            schema=ChildSchema,
+            create_schema=ChildCreate,
+            db_model=Child,
+            prefix=CHILD_URL,
+        )
+    )
+
+    parent = test_router.test_post(client, PARENT_URL, dict())
+    child = test_router.test_post(client, CHILD_URL, dict(parent_id=parent["id"]))
+
+    res = client.get(f'{PARENT_URL}/{parent["id"]}')
+    assert res.status_code == 200, res.json()
+    parent_data = res.json()
+
+    res = client.get(f'{CHILD_URL}/{child["id"]}')
+    assert res.status_code == 200, res.json()
+    child_data = res.json()
+
+    assert type(parent_data["children"]) is list, parent_data
+    assert parent_data["children"][0] == child_data


### PR DESCRIPTION
# FastAPI-CrudRouter + Tortoise

Tortoise models can have 3 "types" of pydantic models:

- Regular pydantic models (BaseModel)
- Uninitiated Tortoise's pydantic models (PydanticModel)
- Initiated Tortoise's pydantic models (PydanticModel + Tortoise.init_models)

## Tortoise initiated vs uninitiated models

Uninitiated models are models that are typically written in a module's body and are not preceded by a `Tortoise.init_models(...)`.
Initiated models are aware of its related models (Foreign fields) and will include these fields in the created Pydantic models

## Test cases:

The proposed test cases are the cross-product of the possible "types" of Pydantic model vs. having nested models or not.

**Cases**:
- [x] No nested - Regular pydantic models (BaseModel)
- [x] No nested - Uninitiated Tortoise's pydantic models (PydanticModel)
- [x] No nested - Initiated Tortoise's pydantic models (PydanticModel + Tortoise.init_models)
- [x] Nested - Regular pydantic models (BaseModel)
- [ ] Nested - Uninitiated Tortoise's pydantic models (PydanticModel)
- [x] Nested - Initiated Tortoise's pydantic models (PydanticModel + Tortoise.init_models)
