### PR TITLE
Confusing exception message at databases.py

### DIFF
--- a/fastapi_crudrouter/core/databases.py
+++ b/fastapi_crudrouter/core/databases.py
@@ -103,8 +103,8 @@ class DatabasesCRUDRouter(CRUDGenerator[PYDANTIC_SCHEMA]):
                 query = self.table.insert()
                 rid = await self.db.execute(query=query, values=schema.dict())
                 return {self._pk: rid, **schema.dict()}
-            except Exception:
-                raise HTTPException(422, "Key already exists")
+            except Exception as e:
+                raise HTTPException(422, str(e))
 
         return route
 


### PR DESCRIPTION
I've been confused of seeing 'Key already exists' right before I printed real exception.