### PR TITLE
Add Default OrderBy for MSSQL

### DIFF
--- a/fastapi_crudrouter/core/sqlalchemy.py
+++ b/fastapi_crudrouter/core/sqlalchemy.py
@@ -70,7 +70,7 @@ class SQLAlchemyCRUDRouter(CRUDGenerator[SCHEMA]):
 
             db_models: List[Model] = (
                 db.query(self.db_model)
-                .order_by(self._pk)
+                .order_by(getattr(self.db_model, self._pk))
                 .limit(limit)
                 .offset(skip)
                 .all()

--- a/fastapi_crudrouter/core/sqlalchemy.py
+++ b/fastapi_crudrouter/core/sqlalchemy.py
@@ -69,7 +69,11 @@ class SQLAlchemyCRUDRouter(CRUDGenerator[SCHEMA]):
             skip, limit = pagination.get("skip"), pagination.get("limit")
 
             db_models: List[Model] = (
-                db.query(self.db_model).limit(limit).offset(skip).all()
+                db.query(self.db_model)
+                .order_by(self._pk)
+                .limit(limit)
+                .offset(skip)
+                .all()
             )
             return db_models
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "0.8.0"
+VERSION = "0.8.1"
 
 setup(
     name="fastapi-crudrouter",


### PR DESCRIPTION
Explicitly states the primary key column as the default column to order by (needed for mssql)

closes #84 