### PR TITLE
Update documentation for a working routing exemple

### DIFF
--- a/docs/en/docs/routing.md
+++ b/docs/en/docs/routing.md
@@ -81,7 +81,7 @@ class Potato(BaseModel):
     mass: float
 
 app = FastAPI()
-router = CRUDRouter(model=mymodel)
+router = CRUDRouter(schema=Potato)
 
 @router.get('')
 def overloaded_get_all():
@@ -90,4 +90,6 @@ def overloaded_get_all():
 @router.get('/{item_id}')
 def overloaded_get_one():
     return 'My overloaded route that returns one item'
+
+app.include_router(router)
 ```


### PR DESCRIPTION
Relates to : https://github.com/awtkns/fastapi-crudrouter/issues/90

As discussed, I think a real `overloaded_get_all` method that return a list of created elements would be great. Working with `MemoryCRUDRouter`