### PR TITLE
Add dependency to token_auth

### DIFF
--- a/docs/en/docs/dependencies.md
+++ b/docs/en/docs/dependencies.md
@@ -14,7 +14,7 @@ from fastapi_crudrouter import MemoryCRUDRouter
 app = FastAPI()
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/token")
 
-def token_auth(token: str):
+def token_auth(token: str=Depends(oauth2_scheme)):
     if not token:
         raise HTTPException(401, "Invalid token")
 


### PR DESCRIPTION
If the dependency is not specified in the argument, the method asks for the `token` parameter in each request. This is clearly seen in the API Docs, which don't show the _Authorize_ button.