### PR TITLE
Correcting several documentation typos

### DIFF
--- a/docs/en/docs/routing.md
+++ b/docs/en/docs/routing.md
@@ -43,7 +43,7 @@ are shown below.
 
 As an example, the *delete all* route can be disabled by doing the following:
 ```python
-router = MemmoryCRUDRouter(schema=MyModel, deleta_all_route=False)
+router = MemoryCRUDRouter(schema=MyModel, delete_all_route=False)
 ```
 
 !!! tip "Custom Dependencies"


### PR DESCRIPTION
`MemmoryCRUDRouter` >> `MemoryCRUDRouter`
`deleta_all_route` >> `delete_all_route`