### PR TITLE
Fix 404 on openapi spec

### DIFF
--- a/fastapi_crudrouter/core/_base.py
+++ b/fastapi_crudrouter/core/_base.py
@@ -3,11 +3,21 @@ from typing import Any, Callable, Generic, List, Optional, Type, Union
 
 from fastapi import APIRouter, HTTPException
 from fastapi.types import DecoratedCallable
+from pydantic import BaseModel
 
-from ._types import T, DEPENDENCIES
+from ._types import DEPENDENCIES, T
 from ._utils import pagination_factory, schema_factory
 
-NOT_FOUND = HTTPException(404, "Item not found")
+
+class NotFoundModel(BaseModel):
+    detail: str
+
+
+NOT_FOUND = {
+    "status_code": 404,
+    "http_exeption": HTTPException(404, "Item not found"),
+    "class_exeption": NotFoundModel,
+}
 
 
 class CRUDGenerator(Generic[T], APIRouter, ABC):
@@ -126,7 +136,10 @@ class CRUDGenerator(Generic[T], APIRouter, ABC):
     ) -> None:
         dependencies = [] if isinstance(dependencies, bool) else dependencies
         responses: Any = (
-            {err.status_code: {"detail": err.detail} for err in error_responses}
+            {
+                err["status_code"]: {"model": err["class_exeption"]}
+                for err in error_responses
+            }
             if error_responses
             else None
         )

--- a/fastapi_crudrouter/core/databases.py
+++ b/fastapi_crudrouter/core/databases.py
@@ -103,7 +103,7 @@ class DatabasesCRUDRouter(CRUDGenerator[PYDANTIC_SCHEMA]):
             if model:
                 return pydantify_record(model)  # type: ignore
             else:
-                raise NOT_FOUND
+                raise NOT_FOUND["http_exeption"]
 
         return route
 
@@ -136,7 +136,7 @@ class DatabasesCRUDRouter(CRUDGenerator[PYDANTIC_SCHEMA]):
                 )
                 return await self._get_one()(item_id)
             except Exception as e:
-                raise NOT_FOUND from e
+                raise NOT_FOUND["http_exeption"] from e
 
         return route
 
@@ -158,6 +158,6 @@ class DatabasesCRUDRouter(CRUDGenerator[PYDANTIC_SCHEMA]):
                 await self.db.execute(query=query)
                 return row
             except Exception as e:
-                raise NOT_FOUND from e
+                raise NOT_FOUND["http_exeption"] from e
 
         return route

--- a/fastapi_crudrouter/core/gino_starlette.py
+++ b/fastapi_crudrouter/core/gino_starlette.py
@@ -86,7 +86,7 @@ class GinoCRUDRouter(CRUDGenerator[SCHEMA]):
             if model:
                 return model
             else:
-                raise NOT_FOUND
+                raise NOT_FOUND["http_exeption"]
 
         return route
 

--- a/fastapi_crudrouter/core/mem.py
+++ b/fastapi_crudrouter/core/mem.py
@@ -62,7 +62,7 @@ class MemoryCRUDRouter(CRUDGenerator[SCHEMA]):
                 if model.id == item_id:  # type: ignore
                     return model
 
-            raise NOT_FOUND
+            raise NOT_FOUND["http_exeption"]
 
         return route
 
@@ -85,7 +85,7 @@ class MemoryCRUDRouter(CRUDGenerator[SCHEMA]):
                     )
                     return self.models[ind]
 
-            raise NOT_FOUND
+            raise NOT_FOUND["http_exeption"]
 
         return route
 
@@ -103,7 +103,7 @@ class MemoryCRUDRouter(CRUDGenerator[SCHEMA]):
                     del self.models[ind]
                     return model
 
-            raise NOT_FOUND
+            raise NOT_FOUND["http_exeption"]
 
         return route
 

--- a/fastapi_crudrouter/core/ormar.py
+++ b/fastapi_crudrouter/core/ormar.py
@@ -87,7 +87,7 @@ class OrmarCRUDRouter(CRUDGenerator[Model]):
                     _exclude=False, **filter_
                 ).first()
             except NoMatch:
-                raise NOT_FOUND from None
+                raise NOT_FOUND["http_exeption"] from None
             return model
 
         return route

--- a/fastapi_crudrouter/core/sqlalchemy.py
+++ b/fastapi_crudrouter/core/sqlalchemy.py
@@ -93,7 +93,7 @@ class SQLAlchemyCRUDRouter(CRUDGenerator[SCHEMA]):
             if model:
                 return model
             else:
-                raise NOT_FOUND from None
+                raise NOT_FOUND["http_exeption"] from None
 
         return route
 

--- a/fastapi_crudrouter/core/tortoise.py
+++ b/fastapi_crudrouter/core/tortoise.py
@@ -74,7 +74,7 @@ class TortoiseCRUDRouter(CRUDGenerator[SCHEMA]):
             if model:
                 return model
             else:
-                raise NOT_FOUND
+                raise NOT_FOUND["http_exeption"]
 
         return route
 


### PR DESCRIPTION
I'm running into issues when running the following command, against an API generated by fastapi-crudrouter (which is great btw 🥇 )

```
>> openapi-generator validate -i http://127.0.0.1:8000/openapi.json
Validating spec (http://127.0.0.1:8000/openapi.json)
Errors:
	- attribute paths.'/tag/{item_id}'(get).responses.404.detail is unexpected
	- attribute paths.'/project/{item_id}'(get).responses.404.detail is unexpected
	- attribute paths.'/tag/{item_id}'(delete).responses.404.detail is unexpected
	- attribute paths.'/project/{item_id}'(delete).responses.404.detail is unexpected
	- attribute paths.'/project/{item_id}'(put).responses.404.detail is unexpected
	- attribute paths.'/tag/{item_id}'(put).responses.404.detail is unexpected

[error] Spec has 6 errors.
```

I believe this PR resolves https://github.com/awtkns/fastapi-crudrouter/issues/105. Picking up on the great example left by @[sondrelg](https://github.com/sondrelg) at https://github.com/awtkns/fastapi-crudrouter/pull/104.

I believe this should also help resolve this PR https://github.com/awtkns/fastapi-crudrouter/pull/141.
