### PR TITLE
modified tortoise _get_one route

### DIFF
--- a/fastapi_crudrouter/core/tortoise.py
+++ b/fastapi_crudrouter/core/tortoise.py
@@ -4,6 +4,7 @@ from . import CRUDGenerator, NOT_FOUND
 from ._types import DEPENDENCIES, PAGINATION, PYDANTIC_SCHEMA as SCHEMA
 
 try:
+    from tortoise.exceptions import DoesNotExist
     from tortoise.models import Model
 except ImportError:
     Model = None  # type: ignore
@@ -69,7 +70,10 @@ class TortoiseCRUDRouter(CRUDGenerator[SCHEMA]):
 
     def _get_one(self, *args: Any, **kwargs: Any) -> CALLABLE:
         async def route(item_id: int) -> Model:
-            return await self.db_model.get(id=item_id)
+            try:
+                return await self.db_model.get(id=item_id)
+            except DoesNotExist:
+                raise NOT_FOUND
 
         return route
 

--- a/fastapi_crudrouter/core/tortoise.py
+++ b/fastapi_crudrouter/core/tortoise.py
@@ -69,12 +69,7 @@ class TortoiseCRUDRouter(CRUDGenerator[SCHEMA]):
 
     def _get_one(self, *args: Any, **kwargs: Any) -> CALLABLE:
         async def route(item_id: int) -> Model:
-            model = await self.db_model.filter(id=item_id).first()
-
-            if model:
-                return model
-            else:
-                raise NOT_FOUND
+            return await self.db_model.get(id=item_id)
 
         return route
 


### PR DESCRIPTION
- Simplification of the _get_one route: use of the get method provided by tortoise instead of using filter. The 404 is still raised if the item does not exist
Note that it changes the error message

