### PR TITLE
Support default_factory on primary keys of schemas for create routes

### DIFF
--- a/fastapi_crudrouter/core/_utils.py
+++ b/fastapi_crudrouter/core/_utils.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type, Any
+from typing import Optional, Type, Any, Tuple
 
 from fastapi import Depends, HTTPException
 from pydantic import create_model
@@ -21,7 +21,7 @@ def get_pk_type(schema: Type[PYDANTIC_SCHEMA], pk_field: str) -> Any:
 
 def create_schema_default_factory(
     schema_cls: Type[T], create_schema_instance: T, pk_field_name: str = "id"
-) -> T:
+) -> Tuple[T, bool]:
     """
     Is used to check for default_factory for the pk on a Schema,
     passing the CreateSchema values into the Schema if a
@@ -29,9 +29,9 @@ def create_schema_default_factory(
     """
 
     if callable(schema_cls.__fields__[pk_field_name].default_factory):
-        return schema_cls(**create_schema_instance.dict())
+        return schema_cls(**create_schema_instance.dict()), True
     else:
-        return create_schema_instance
+        return create_schema_instance, False
 
 
 def schema_factory(

--- a/fastapi_crudrouter/core/_utils.py
+++ b/fastapi_crudrouter/core/_utils.py
@@ -19,6 +19,21 @@ def get_pk_type(schema: Type[PYDANTIC_SCHEMA], pk_field: str) -> Any:
         return int
 
 
+def create_schema_default_factory(
+    schema_cls: Type[T], create_schema_instance: T, pk_field_name: str = "id"
+) -> T:
+    """
+    Is used to check for default_factory for the pk on a Schema,
+    passing the CreateSchema values into the Schema if a
+    default_factory on the pk exists
+    """
+
+    if callable(schema_cls.__fields__[pk_field_name].default_factory):
+        return schema_cls(**create_schema_instance.dict())
+    else:
+        return create_schema_instance
+
+
 def schema_factory(
     schema_cls: Type[T], pk_field_name: str = "id", name: str = "Create"
 ) -> Type[T]:

--- a/fastapi_crudrouter/core/databases.py
+++ b/fastapi_crudrouter/core/databases.py
@@ -111,7 +111,7 @@ class DatabasesCRUDRouter(CRUDGenerator[PYDANTIC_SCHEMA]):
         async def route(
             schema: self.create_schema,  # type: ignore
         ) -> Model:
-            schema = create_schema_default_factory(schema_cls=self.schema, create_schema_instance=schema, pk_field_name=self._pk)
+            schema, _ = create_schema_default_factory(schema_cls=self.schema, create_schema_instance=schema, pk_field_name=self._pk)
             query = self.table.insert()
 
             try:

--- a/fastapi_crudrouter/core/databases.py
+++ b/fastapi_crudrouter/core/databases.py
@@ -13,7 +13,7 @@ from fastapi import HTTPException
 
 from . import CRUDGenerator, NOT_FOUND
 from ._types import PAGINATION, PYDANTIC_SCHEMA, DEPENDENCIES
-from ._utils import AttrDict, get_pk_type
+from ._utils import AttrDict, get_pk_type, create_schema_default_factory
 
 try:
     from sqlalchemy.sql.schema import Table
@@ -111,6 +111,7 @@ class DatabasesCRUDRouter(CRUDGenerator[PYDANTIC_SCHEMA]):
         async def route(
             schema: self.create_schema,  # type: ignore
         ) -> Model:
+            schema = create_schema_default_factory(schema_cls=self.schema, create_schema_instance=schema, pk_field_name=self._pk)
             query = self.table.insert()
 
             try:

--- a/fastapi_crudrouter/core/gino_starlette.py
+++ b/fastapi_crudrouter/core/gino_starlette.py
@@ -5,6 +5,7 @@ from fastapi import HTTPException
 from . import NOT_FOUND, CRUDGenerator, _utils
 from ._types import DEPENDENCIES, PAGINATION
 from ._types import PYDANTIC_SCHEMA as SCHEMA
+from ._utils import create_schema_default_factory
 
 try:
     from asyncpg.exceptions import UniqueViolationError
@@ -94,6 +95,8 @@ class GinoCRUDRouter(CRUDGenerator[SCHEMA]):
         async def route(
             model: self.create_schema,  # type: ignore
         ) -> Model:
+            model = create_schema_default_factory(schema_cls=self.schema, create_schema_instance=model, pk_field_name=self._pk)
+
             try:
                 async with self.db.transaction():
                     db_model: Model = await self.db_model.create(**model.dict())

--- a/fastapi_crudrouter/core/gino_starlette.py
+++ b/fastapi_crudrouter/core/gino_starlette.py
@@ -95,7 +95,7 @@ class GinoCRUDRouter(CRUDGenerator[SCHEMA]):
         async def route(
             model: self.create_schema,  # type: ignore
         ) -> Model:
-            model = create_schema_default_factory(schema_cls=self.schema, create_schema_instance=model, pk_field_name=self._pk)
+            model, _ = create_schema_default_factory(schema_cls=self.schema, create_schema_instance=model, pk_field_name=self._pk)
 
             try:
                 async with self.db.transaction():

--- a/fastapi_crudrouter/core/mem.py
+++ b/fastapi_crudrouter/core/mem.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, List, Type, cast, Optional, Union
 
 from . import CRUDGenerator, NOT_FOUND
 from ._types import DEPENDENCIES, PAGINATION, PYDANTIC_SCHEMA as SCHEMA
+from ._utils import create_schema_default_factory
 
 CALLABLE = Callable[..., SCHEMA]
 CALLABLE_LIST = Callable[..., List[SCHEMA]]
@@ -68,6 +69,7 @@ class MemoryCRUDRouter(CRUDGenerator[SCHEMA]):
 
     def _create(self, *args: Any, **kwargs: Any) -> CALLABLE:
         def route(model: self.create_schema) -> SCHEMA:  # type: ignore
+            model = create_schema_default_factory(schema_cls=self.schema, create_schema_instance=model, pk_field_name=self._pk)
             model_dict = model.dict()
             model_dict["id"] = self._get_next_id()
             ready_model = self.schema(**model_dict)

--- a/fastapi_crudrouter/core/ormar.py
+++ b/fastapi_crudrouter/core/ormar.py
@@ -13,6 +13,7 @@ from fastapi import HTTPException
 
 from . import CRUDGenerator, NOT_FOUND, _utils
 from ._types import DEPENDENCIES, PAGINATION
+from ._utils import create_schema_default_factory
 
 try:
     from ormar import Model, NoMatch
@@ -94,6 +95,7 @@ class OrmarCRUDRouter(CRUDGenerator[Model]):
 
     def _create(self, *args: Any, **kwargs: Any) -> CALLABLE:
         async def route(model: self.create_schema) -> Model:  # type: ignore
+            model = create_schema_default_factory(schema_cls=self.schema, create_schema_instance=model, pk_field_name=self._pk)
             model_dict = model.dict()
             if self.schema.Meta.model_fields[self._pk].autoincrement:
                 model_dict.pop(self._pk, None)

--- a/fastapi_crudrouter/core/ormar.py
+++ b/fastapi_crudrouter/core/ormar.py
@@ -95,7 +95,7 @@ class OrmarCRUDRouter(CRUDGenerator[Model]):
 
     def _create(self, *args: Any, **kwargs: Any) -> CALLABLE:
         async def route(model: self.create_schema) -> Model:  # type: ignore
-            model = create_schema_default_factory(schema_cls=self.schema, create_schema_instance=model, pk_field_name=self._pk)
+            model, _ = create_schema_default_factory(schema_cls=self.schema, create_schema_instance=model, pk_field_name=self._pk)
             model_dict = model.dict()
             if self.schema.Meta.model_fields[self._pk].autoincrement:
                 model_dict.pop(self._pk, None)

--- a/fastapi_crudrouter/core/sqlalchemy.py
+++ b/fastapi_crudrouter/core/sqlalchemy.py
@@ -103,7 +103,7 @@ class SQLAlchemyCRUDRouter(CRUDGenerator[SCHEMA]):
             model: self.create_schema,  # type: ignore
             db: Session = Depends(self.db_func),
         ) -> Model:
-            model = create_schema_default_factory(schema_cls=self.schema, create_schema_instance=model, pk_field_name=self._pk)
+            model, _ = create_schema_default_factory(schema_cls=self.schema, create_schema_instance=model, pk_field_name=self._pk)
 
             try:
                 db_model: Model = self.db_model(**model.dict())

--- a/fastapi_crudrouter/core/sqlalchemy.py
+++ b/fastapi_crudrouter/core/sqlalchemy.py
@@ -4,6 +4,7 @@ from fastapi import Depends, HTTPException
 
 from . import CRUDGenerator, NOT_FOUND, _utils
 from ._types import DEPENDENCIES, PAGINATION, PYDANTIC_SCHEMA as SCHEMA
+from ._utils import create_schema_default_factory
 
 try:
     from sqlalchemy.orm import Session
@@ -102,6 +103,8 @@ class SQLAlchemyCRUDRouter(CRUDGenerator[SCHEMA]):
             model: self.create_schema,  # type: ignore
             db: Session = Depends(self.db_func),
         ) -> Model:
+            model = create_schema_default_factory(schema_cls=self.schema, create_schema_instance=model, pk_field_name=self._pk)
+
             try:
                 db_model: Model = self.db_model(**model.dict())
                 db.add(db_model)

--- a/fastapi_crudrouter/core/tortoise.py
+++ b/fastapi_crudrouter/core/tortoise.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, List, Type, cast, Coroutine, Optional, Union
 
 from . import CRUDGenerator, NOT_FOUND
 from ._types import DEPENDENCIES, PAGINATION, PYDANTIC_SCHEMA as SCHEMA
+from ._utils import create_schema_default_factory
 
 try:
     from tortoise.models import Model
@@ -80,6 +81,7 @@ class TortoiseCRUDRouter(CRUDGenerator[SCHEMA]):
 
     def _create(self, *args: Any, **kwargs: Any) -> CALLABLE:
         async def route(model: self.create_schema) -> Model:  # type: ignore
+            model = create_schema_default_factory(schema_cls=self.schema, create_schema_instance=model, pk_field_name=self._pk)
             db_model = self.db_model(**model.dict())
             await db_model.save()
 

--- a/fastapi_crudrouter/core/tortoise.py
+++ b/fastapi_crudrouter/core/tortoise.py
@@ -81,7 +81,7 @@ class TortoiseCRUDRouter(CRUDGenerator[SCHEMA]):
 
     def _create(self, *args: Any, **kwargs: Any) -> CALLABLE:
         async def route(model: self.create_schema) -> Model:  # type: ignore
-            model = create_schema_default_factory(schema_cls=self.schema, create_schema_instance=model, pk_field_name=self._pk)
+            model, _ = create_schema_default_factory(schema_cls=self.schema, create_schema_instance=model, pk_field_name=self._pk)
             db_model = self.db_model(**model.dict())
             await db_model.save()
 


### PR DESCRIPTION
Pydantic has a way to [specify a function](https://pydantic-docs.helpmanual.io/usage/models/#field-with-dynamic-default-value) that provides a default value for a field.

This pull request adds support for this in [fastapi-crudrouter](https://github.com/awtkns/fastapi-crudrouter), for primary keys that utilize this.

Example:
```
from secrets import choice
from pydantic import BaseModel, Field
from fastapi import FastAPI
from fastapi_crudrouter import MemoryCRUDRouter as CRUDRouter

class Potato(BaseModel):
    id: int = Field(default_factory=lambda: choice(range(0,3)))
    color: str
    mass: float

app = FastAPI()
app.include_router(CRUDRouter(schema=Potato))
```
