### PR TITLE
Update sqlalchemy.py

### DIFF
--- a/fastapi_crudrouter/core/sqlalchemy.py
+++ b/fastapi_crudrouter/core/sqlalchemy.py
@@ -26,7 +26,7 @@ class SQLAlchemyCRUDRouter(CRUDGenerator[SCHEMA]):
     def __init__(
         self,
         schema: Type[SCHEMA],
-        db_model: Model,
+        db_model: Type[Model],
         db: "Session",
         create_schema: Optional[Type[SCHEMA]] = None,
         update_schema: Optional[Type[SCHEMA]] = None,


### PR DESCRIPTION
Generally, define the sql model as SQLALCHEMY.
The models extends Base.
Parent of base is Model, but type of child Model is not Model.
Therefore I fix type of db_model in SQLAlchemyCRUDRouter.

Finally warnning is shutdown.