### PR TITLE
Fix route response_model typing

### DIFF
--- a/fastapi_crudrouter/core/_base.py
+++ b/fastapi_crudrouter/core/_base.py
@@ -58,7 +58,7 @@ class CRUDGenerator(Generic[T], APIRouter, ABC):
                 "",
                 self._get_all(),
                 methods=["GET"],
-                response_model=Optional[List[self.schema]],  # type: ignore
+                response_model=List[self.schema],  # type: ignore
                 summary="Get All",
                 dependencies=get_all_route,
             )
@@ -78,7 +78,7 @@ class CRUDGenerator(Generic[T], APIRouter, ABC):
                 "",
                 self._delete_all(),
                 methods=["DELETE"],
-                response_model=Optional[List[self.schema]],  # type: ignore
+                response_model=List[self.schema],  # type: ignore
                 summary="Delete All",
                 dependencies=delete_all_route,
             )


### PR DESCRIPTION
As the response is always a list (even if it's empty), we can remove the Optional.