### PR TITLE
Fix bugs that are not compatible with pydantic2.x

### DIFF
--- a/fastapi_crudrouter/core/_utils.py
+++ b/fastapi_crudrouter/core/_utils.py
@@ -26,11 +26,23 @@ def schema_factory(
     Is used to create a CreateSchema which does not contain pk
     """
 
-    fields = {
-        f.name: (f.type_, ...)
-        for f in schema_cls.__fields__.values()
-        if f.name != pk_field_name
-    }
+    # for handle pydantic 2.x migration
+    from pydantic import __version__ as pydantic_version
+
+    if int(pydantic_version.split(".")[0]) >= 2:
+        # pydantic 2.x
+        fields = {
+            fk: (fv.annotation, ...)
+            for fk, fv in schema_cls.model_fields.items()
+            if fk != pk_field_name
+        }
+    else:
+        # pydantic 1.x
+        fields = {
+            f.name: (f.type_, ...)
+            for f in schema_cls.__fields__.values()
+            if f.name != pk_field_name
+        }
 
     name = schema_cls.__name__ + name
     schema: Type[T] = create_model(__model_name=name, **fields)  # type: ignore

--- a/fastapi_crudrouter/core/_utils.py
+++ b/fastapi_crudrouter/core/_utils.py
@@ -14,7 +14,10 @@ class AttrDict(dict):  # type: ignore
 
 def get_pk_type(schema: Type[PYDANTIC_SCHEMA], pk_field: str) -> Any:
     try:
-        return schema.__fields__[pk_field].type_
+        if int(pydantic_version.split(".")[0]) >= 2:
+            return schema.model_fields[pk_field].annotation
+        else:
+            return schema.__fields__[pk_field].type_
     except KeyError:
         return int
 

--- a/fastapi_crudrouter/core/_utils.py
+++ b/fastapi_crudrouter/core/_utils.py
@@ -2,9 +2,11 @@ from typing import Optional, Type, Any
 
 from fastapi import Depends, HTTPException
 from pydantic import create_model
+from pydantic import __version__ as pydantic_version
 
 from ._types import T, PAGINATION, PYDANTIC_SCHEMA
 
+PYDANTIC_MAJOR_VERSION = int(pydantic_version.split(".", maxsplit=1)[0])
 
 class AttrDict(dict):  # type: ignore
     def __init__(self, *args, **kwargs) -> None:  # type: ignore
@@ -14,10 +16,7 @@ class AttrDict(dict):  # type: ignore
 
 def get_pk_type(schema: Type[PYDANTIC_SCHEMA], pk_field: str) -> Any:
     try:
-        # for handle pydantic 2.x migration
-        from pydantic import __version__ as pydantic_version
-        
-        if int(pydantic_version.split(".")[0]) >= 2:
+        if PYDANTIC_MAJOR_VERSION >= 2:
             return schema.model_fields[pk_field].annotation
         else:
             return schema.__fields__[pk_field].type_
@@ -32,10 +31,7 @@ def schema_factory(
     Is used to create a CreateSchema which does not contain pk
     """
 
-    # for handle pydantic 2.x migration
-    from pydantic import __version__ as pydantic_version
-
-    if int(pydantic_version.split(".")[0]) >= 2:
+    if PYDANTIC_MAJOR_VERSION >= 2:
         # pydantic 2.x
         fields = {
             fk: (fv.annotation, ...)

--- a/fastapi_crudrouter/core/_utils.py
+++ b/fastapi_crudrouter/core/_utils.py
@@ -14,6 +14,9 @@ class AttrDict(dict):  # type: ignore
 
 def get_pk_type(schema: Type[PYDANTIC_SCHEMA], pk_field: str) -> Any:
     try:
+        # for handle pydantic 2.x migration
+        from pydantic import __version__ as pydantic_version
+        
         if int(pydantic_version.split(".")[0]) >= 2:
             return schema.model_fields[pk_field].annotation
         else:


### PR DESCRIPTION
I solved the problem that fastapi-crudrouter is not compatible with pydantic2.x, related issue #189,  #190
The changes only involve ```fastapi_crudrouter/core/_utils.py```